### PR TITLE
Replace Singleton Registry With Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ def some_method() -> None:
 or via a decorator
 
 ```python
-from pylemetry import Registry
+from pylemetry import registry
 from pylemetry.decorators import count
 
 
@@ -51,37 +51,37 @@ def main() -> None:
         some_method()
         another_method()
 
-    counter = Registry().get_counter("some_method")
+    counter = registry.get_counter("some_method")
     counter.get_count()  # 100
 
-    counter = Registry.get_counter("named_counter")
+    counter = registry.get_counter("named_counter")
     counter.get_count()  # 100
 ```
 
-When using this meter via a decorator, the meter gets added to the global `Registry`, with the method name it's decorating as the meter name. Alternatively, you can provide a name for the meter as a parameter to the decorator
+When using this meter via a decorator, the meter gets added to the global `registry`, with the method name it's decorating as the meter name. Alternatively, you can provide a name for the meter as a parameter to the decorator
 
 ## Gauge
 
 A `Gauge` meter allows you to keep track of varying metrics, e.g. memory usage or items on a queue. This meter currently isn't supported as a decorator
 
 ```python
-from pylemetry import Registry
+from pylemetry import registry
 from pylemetry.meters import Gauge
 
 
 def some_method() -> None:
     gauge = Gauge()
     
-    Registry().add_gauge("sample_gauge", gauge)
+    registry.add_gauge("sample_gauge", gauge)
 ```
 
 The `Gauge` supports incrementing, decrementing, and setting a value directly
 
 ```python
-from pylemetry import Registry
+from pylemetry import registry
 
 
-gauge = Registry().get_gauge("sample_gauge")
+gauge = registry.get_gauge("sample_gauge")
 
 gauge.add(10)
 gauge += 1.5
@@ -89,7 +89,7 @@ gauge.get_value()  # 11.5
 
 gauge.subtract(10)
 gauge -= 8.5
-gauge.get_value()  # -8
+gauge.get_value()  # -7
 
 gauge.set_value(7.5)
 gauge.get_value()  # 7.5
@@ -117,7 +117,7 @@ def some_method() -> None:
 or via a decorator
 
 ```python
-from pylemetry import Registry
+from pylemetry import registry
 from pylemetry.decorators import time
 
 
@@ -136,18 +136,18 @@ def main() -> None:
         some_method()
         another_method()
         
-    timer = Registry().get_timer("some_method")
+    timer = registry.get_timer("some_method")
     timer.get_count()  # 100
     timer.get_mean_tick_time()  # Mean execution time of the some_method function
     timer.get_max_tick_time()  # Maximum execution time of the some_method function
     timer.get_min_tick_time()  # Minimum execution time of the some_method function
 
-    timer = Registry().get_timer("named_timer")
+    timer = registry.get_timer("named_timer")
     timer.get_count()  # 100
     ...
 ```
 
-When using this meter via a decorator, the meter gets added to the global `Registry`, with the method name it's decorating as the meter name. Alternatively, you can provide a name for the meter as a parameter to the decorator
+When using this meter via a decorator, the meter gets added to the global `registry`, with the method name it's decorating as the meter name. Alternatively, you can provide a name for the meter as a parameter to the decorator
 
 ## The Registry
 
@@ -155,7 +155,7 @@ Pylemetry maintains a global registry of meters, allowing you to share a meter a
 This registry is also used to keep track of all metrics created by decorators, with those meters registered using the method name they are decorating
 
 ```python
-from pylemetry import Registry
+from pylemetry import registry
 from pylemetry.meters import Counter, Gauge, Timer
 
 
@@ -163,11 +163,11 @@ counter = Counter()
 gauge = Gauge()
 timer = Timer()
 
-Registry().add_counter("example", counter)
-Registry().add_gauge("example", gauge)
-Registry().add_timer("example", timer)
+registry.add_counter("example", counter)
+registry.add_gauge("example", gauge)
+registry.add_timer("example", timer)
 ```
 
-Each meter type has an `add_meter`, `get_meter` and `remove_meter` method to manage meters in the `Registry`, each requiring a unique meter name.
+Each meter type has an `add_meter`, `get_meter` and `remove_meter` method to manage meters in the `registry`, each requiring a unique meter name.
 
-The `Registry` can be cleared through the `clear()` method
+The `registry` can be cleared through the `clear()` method

--- a/src/pylemetry/__init__.py
+++ b/src/pylemetry/__init__.py
@@ -1,4 +1,0 @@
-from .registry import Registry
-
-
-__all__ = ["Registry"]

--- a/src/pylemetry/decorators/count.py
+++ b/src/pylemetry/decorators/count.py
@@ -2,7 +2,7 @@ from typing import Callable, Any, Optional
 
 from functools import wraps
 
-from pylemetry import Registry
+from pylemetry import registry
 from pylemetry.meters import Counter
 
 
@@ -20,11 +20,11 @@ def count(name: Optional[str] = None) -> Callable[..., Any]:
         def wrapper() -> Any:
             counter_name = f.__qualname__ if name is None else name
 
-            counter = Registry().get_counter(counter_name)
+            counter = registry.get_counter(counter_name)
 
             if not counter:
                 counter = Counter()
-                Registry().add_counter(counter_name, counter)
+                registry.add_counter(counter_name, counter)
 
             counter += 1
 

--- a/src/pylemetry/decorators/time.py
+++ b/src/pylemetry/decorators/time.py
@@ -2,7 +2,7 @@ from typing import Callable, Any, Optional
 
 from functools import wraps
 
-from pylemetry import Registry
+from pylemetry import registry
 from pylemetry.meters import Timer
 
 
@@ -20,11 +20,11 @@ def time(name: Optional[str] = None) -> Callable[..., Any]:
         def wrapper() -> Any:
             time_name = f.__qualname__ if name is None else name
 
-            _timer = Registry().get_timer(time_name)
+            _timer = registry.get_timer(time_name)
 
             if not _timer:
                 _timer = Timer()
-                Registry().add_timer(time_name, _timer)
+                registry.add_timer(time_name, _timer)
 
             with _timer.time():
                 return f()

--- a/src/pylemetry/registry.py
+++ b/src/pylemetry/registry.py
@@ -1,137 +1,132 @@
-from threading import Lock
+from typing import Optional
 
 from pylemetry.meters import Counter, Gauge, Timer
 
 
-class SingletonMeta(type):
-    _instances: dict[type, object] = {}
-    _lock = Lock()
-
-    def __call__(cls, *args, **kwargs):
-        with cls._lock:
-            if cls not in cls._instances:
-                instance = super().__call__(*args, **kwargs)
-                cls._instances[cls] = instance
-
-        return cls._instances[cls]
+COUNTERS: dict[str, Counter] = {}
+GAUGES: dict[str, Gauge] = {}
+TIMERS: dict[str, Timer] = {}
 
 
-class Registry(metaclass=SingletonMeta):
-    def __init__(self):
-        self.counters = {}
-        self.gauges = {}
-        self.timers = {}
+def clear() -> None:
+    """
+    Remove all meters from the global registry
+    """
 
-    def clear(self) -> None:
-        """
-        Remove all meters from the global registry
-        """
+    COUNTERS.clear()
+    GAUGES.clear()
+    TIMERS.clear()
 
-        self.counters = {}
-        self.gauges = {}
-        self.timers = {}
 
-    def add_counter(self, name: str, counter: Counter) -> None:
-        """
-        Add a counter to the global registry
+def add_counter(name: str, counter: Counter) -> None:
+    """
+    Add a counter to the global registry
 
-        :param name: Unique name of the counter
-        :param counter: Counter to add
+    :param name: Unique name of the counter
+    :param counter: Counter to add
 
-        :raises AttributeError: When the name provided for the counter metric is already in use in the global registry
-        """
+    :raises AttributeError: When the name provided for the counter metric is already in use in the global registry
+    """
 
-        if name in self.counters:
-            raise AttributeError(f"A counter with the name '{name}' already exists")
+    if name in COUNTERS:
+        raise AttributeError(f"A counter with the name '{name}' already exists")
 
-        self.counters[name] = counter
+    COUNTERS[name] = counter
 
-    def get_counter(self, name: str) -> Counter:
-        """
-        Get a counter from the global registry by its name
 
-        :param name: Name of the counter
-        :return: Counter in the global registry
-        """
+def get_counter(name: str) -> Optional[Counter]:
+    """
+    Get a counter from the global registry by its name
 
-        return self.counters.get(name)
+    :param name: Name of the counter
+    :return: Counter in the global registry
+    """
 
-    def remove_counter(self, name: str) -> None:
-        """
-        Remove a counter from the global registry
+    return COUNTERS.get(name)
 
-        :param name: Name of the counter to remove
-        """
 
-        if name in self.counters:
-            del self.counters[name]
+def remove_counter(name: str) -> None:
+    """
+    Remove a counter from the global registry
 
-    def add_gauge(self, name: str, gauge: Gauge) -> None:
-        """
-        Add a gauge to the global registry
+    :param name: Name of the counter to remove
+    """
 
-        :param name: Unique name of the gauge
-        :param gauge: Gauge to add
+    if name in COUNTERS:
+        del COUNTERS[name]
 
-        :raises AttributeError: When the name provided for the gauge metric is already in use in the global registry
-        """
 
-        if name in self.gauges:
-            raise AttributeError(f"A gauge with the name '{name}' already exists")
+def add_gauge(name: str, gauge: Gauge) -> None:
+    """
+    Add a gauge to the global registry
 
-        self.gauges[name] = gauge
+    :param name: Unique name of the gauge
+    :param gauge: Gauge to add
 
-    def get_gauge(self, name: str) -> Gauge:
-        """
-        Get a gauge from the global registry by its name
+    :raises AttributeError: When the name provided for the gauge metric is already in use in the global registry
+    """
 
-        :param name: Name of the gauge
-        :return: Gauge in the global registry
-        """
+    if name in GAUGES:
+        raise AttributeError(f"A gauge with the name '{name}' already exists")
 
-        return self.gauges.get(name)
+    GAUGES[name] = gauge
 
-    def remove_gauge(self, name: str) -> None:
-        """
-        Remove a gauge from the global registry
 
-        :param name: Name of the gauge to remove
-        """
+def get_gauge(name: str) -> Optional[Gauge]:
+    """
+    Get a gauge from the global registry by its name
 
-        if name in self.gauges:
-            del self.gauges[name]
+    :param name: Name of the gauge
+    :return: Gauge in the global registry
+    """
 
-    def add_timer(self, name: str, timer: Timer) -> None:
-        """
-        Add a timer to the global registry
+    return GAUGES.get(name)
 
-        :param name: Unique name of the timer
-        :param timer: Timer to add
 
-        :raises AttributeError: When the name provided for the timer metric is already in use in the global registry
-        """
+def remove_gauge(name: str) -> None:
+    """
+    Remove a gauge from the global registry
 
-        if name in self.timers:
-            raise AttributeError(f"A timer with the name '{name}' already exists")
+    :param name: Name of the gauge to remove
+    """
 
-        self.timers[name] = timer
+    if name in GAUGES:
+        del GAUGES[name]
 
-    def get_timer(self, name: str) -> Timer:
-        """
-        Get a timer from the global registry by its name
 
-        :param name: Name of the timer
-        :return: Timer in the global registry
-        """
+def add_timer(name: str, timer: Timer) -> None:
+    """
+    Add a timer to the global registry
 
-        return self.timers.get(name)
+    :param name: Unique name of the timer
+    :param timer: Timer to add
 
-    def remove_timer(self, name: str) -> None:
-        """
-        Remove a timer from the global registry
+    :raises AttributeError: When the name provided for the timer metric is already in use in the global registry
+    """
 
-        :param name: Name of the timer to remove
-        """
+    if name in TIMERS:
+        raise AttributeError(f"A timer with the name '{name}' already exists")
 
-        if name in self.timers:
-            del self.timers[name]
+    TIMERS[name] = timer
+
+
+def get_timer(name: str) -> Optional[Timer]:
+    """
+    Get a timer from the global registry by its name
+
+    :param name: Name of the timer
+    :return: Timer in the global registry
+    """
+
+    return TIMERS.get(name)
+
+
+def remove_timer(name: str) -> None:
+    """
+    Remove a timer from the global registry
+
+    :param name: Name of the timer to remove
+    """
+
+    if name in TIMERS:
+        del TIMERS[name]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,8 +1,8 @@
 import pytest
 
-from pylemetry import Registry
+from pylemetry import registry
 
 
 @pytest.fixture(autouse=True)
 def clear_registry() -> None:
-    Registry().clear()
+    registry.clear()

--- a/test/test_pylemetry/decorators/test_count.py
+++ b/test/test_pylemetry/decorators/test_count.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pylemetry import Registry
+from pylemetry import registry
 from pylemetry.decorators import count
 from pylemetry.meters import Counter
 
@@ -13,11 +13,11 @@ def mock_function() -> str:
 def test_count_decorator_creates_counter_in_registry() -> None:
     counter_name = "mock_function"
 
-    assert Registry().get_counter(counter_name) is None
+    assert registry.get_counter(counter_name) is None
 
     mock_function()
 
-    counter = Registry().get_counter(counter_name)
+    counter = registry.get_counter(counter_name)
 
     assert isinstance(counter, Counter)
     assert counter.get_count() == 1
@@ -27,12 +27,12 @@ def test_count_decorator_creates_counter_in_registry() -> None:
 def test_count_decorator_updates_existing_counter(call_count: int) -> None:
     counter_name = "mock_function"
 
-    assert Registry().get_counter(counter_name) is None
+    assert registry.get_counter(counter_name) is None
 
     for _ in range(call_count):
         mock_function()
 
-    counter = Registry().get_counter(counter_name)
+    counter = registry.get_counter(counter_name)
 
     assert isinstance(counter, Counter)
     assert counter.get_count() == call_count
@@ -45,4 +45,4 @@ def test_count_decorator_with_name() -> None:
 
     mock()
 
-    assert "test_count_meter" in Registry().counters
+    assert "test_count_meter" in registry.COUNTERS

--- a/test/test_pylemetry/decorators/test_time.py
+++ b/test/test_pylemetry/decorators/test_time.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pylemetry import Registry
+from pylemetry import registry
 from pylemetry.decorators import time
 from pylemetry.meters import Timer
 
@@ -13,11 +13,11 @@ def mock_function() -> str:
 def test_timer_decorator_creates_counter_in_registry() -> None:
     timer_name = "mock_function"
 
-    assert Registry().get_timer(timer_name) is None
+    assert registry.get_timer(timer_name) is None
 
     mock_function()
 
-    timer = Registry().get_timer(timer_name)
+    timer = registry.get_timer(timer_name)
 
     assert isinstance(timer, Timer)
     assert timer.get_count() == 1
@@ -28,12 +28,12 @@ def test_timer_decorator_creates_counter_in_registry() -> None:
 def test_count_decorator_updates_existing_counter(call_count: int) -> None:
     timer_name = "mock_function"
 
-    assert Registry().get_timer(timer_name) is None
+    assert registry.get_timer(timer_name) is None
 
     for _ in range(call_count):
         mock_function()
 
-    timer = Registry().get_timer(timer_name)
+    timer = registry.get_timer(timer_name)
 
     assert isinstance(timer, Timer)
     assert timer.get_count() == call_count
@@ -47,4 +47,4 @@ def test_time_decorator_with_name() -> None:
 
     mock()
 
-    assert "test_timer_meter" in Registry().timers
+    assert "test_timer_meter" in registry.TIMERS

--- a/test/test_pylemetry/test_registry.py
+++ b/test/test_pylemetry/test_registry.py
@@ -1,37 +1,30 @@
 import pytest
 
-from pylemetry import Registry
+from pylemetry import registry
 from pylemetry.meters import Counter, Gauge, Timer
-
-
-def test_registry_singleton() -> None:
-    registry = Registry()
-    second_registry = Registry()
-
-    assert registry == second_registry
 
 
 def test_add_counter() -> None:
     counter = Counter()
     counter_name = "test_counter"
 
-    Registry().add_counter(counter_name, counter)
+    registry.add_counter(counter_name, counter)
 
-    assert len(Registry().counters) == 1
-    assert counter_name in Registry().counters
-    assert Registry().counters[counter_name] == counter
+    assert len(registry.COUNTERS) == 1
+    assert counter_name in registry.COUNTERS
+    assert registry.COUNTERS[counter_name] == counter
 
 
 def test_add_counter_already_exists() -> None:
     counter = Counter()
     counter_name = "test_counter"
 
-    Registry().add_counter(counter_name, counter)
+    registry.add_counter(counter_name, counter)
 
     with pytest.raises(AttributeError) as exec_info:
         new_counter = Counter()
 
-        Registry().add_counter(counter_name, new_counter)
+        registry.add_counter(counter_name, new_counter)
 
     assert exec_info.value.args[0] == f"A counter with the name '{counter_name}' already exists"
 
@@ -40,9 +33,9 @@ def test_get_counter() -> None:
     counter = Counter()
     counter_name = "test_counter"
 
-    Registry().add_counter(counter_name, counter)
+    registry.add_counter(counter_name, counter)
 
-    new_counter = Registry().get_counter(counter_name)
+    new_counter = registry.get_counter(counter_name)
 
     assert new_counter == counter
 
@@ -51,37 +44,37 @@ def test_remove_counter() -> None:
     counter = Counter()
     counter_name = "test_counter"
 
-    Registry().add_counter(counter_name, counter)
+    registry.add_counter(counter_name, counter)
 
-    assert counter_name in Registry().counters
+    assert counter_name in registry.COUNTERS
 
-    Registry().remove_counter(counter_name)
+    registry.remove_counter(counter_name)
 
-    assert len(Registry().counters) == 0
-    assert counter_name not in Registry().counters
+    assert len(registry.COUNTERS) == 0
+    assert counter_name not in registry.COUNTERS
 
 
 def test_add_gauge() -> None:
     gauge = Gauge()
     gauge_name = "test_gauge"
 
-    Registry().add_gauge(gauge_name, gauge)
+    registry.add_gauge(gauge_name, gauge)
 
-    assert len(Registry().gauges) == 1
-    assert gauge_name in Registry().gauges
-    assert Registry().gauges[gauge_name] == gauge
+    assert len(registry.GAUGES) == 1
+    assert gauge_name in registry.GAUGES
+    assert registry.GAUGES[gauge_name] == gauge
 
 
 def test_add_gauge_already_exists() -> None:
     gauge = Gauge()
     gauge_name = "test_gauge"
 
-    Registry().add_gauge(gauge_name, gauge)
+    registry.add_gauge(gauge_name, gauge)
 
     with pytest.raises(AttributeError) as exec_info:
         new_gauge = Gauge()
 
-        Registry().add_gauge(gauge_name, new_gauge)
+        registry.add_gauge(gauge_name, new_gauge)
 
     assert exec_info.value.args[0] == f"A gauge with the name '{gauge_name}' already exists"
 
@@ -90,9 +83,9 @@ def test_get_gauge() -> None:
     gauge = Gauge()
     gauge_name = "test_gauge"
 
-    Registry().add_gauge(gauge_name, gauge)
+    registry.add_gauge(gauge_name, gauge)
 
-    new_gauge = Registry().get_gauge(gauge_name)
+    new_gauge = registry.get_gauge(gauge_name)
 
     assert new_gauge == gauge
 
@@ -101,37 +94,37 @@ def test_remove_gauge() -> None:
     gauge = Gauge()
     gauge_name = "test_gauge"
 
-    Registry().add_gauge(gauge_name, gauge)
+    registry.add_gauge(gauge_name, gauge)
 
-    assert gauge_name in Registry().gauges
+    assert gauge_name in registry.GAUGES
 
-    Registry().remove_gauge(gauge_name)
+    registry.remove_gauge(gauge_name)
 
-    assert len(Registry().gauges) == 0
-    assert gauge_name not in Registry().gauges
+    assert len(registry.GAUGES) == 0
+    assert gauge_name not in registry.GAUGES
 
 
 def test_add_timer() -> None:
     timer = Timer()
     timer_name = "test_timer"
 
-    Registry().add_timer(timer_name, timer)
+    registry.add_timer(timer_name, timer)
 
-    assert len(Registry().timers) == 1
-    assert timer_name in Registry().timers
-    assert Registry().timers[timer_name] == timer
+    assert len(registry.TIMERS) == 1
+    assert timer_name in registry.TIMERS
+    assert registry.TIMERS[timer_name] == timer
 
 
 def test_add_timer_already_exists() -> None:
     timer = Timer()
     timer_name = "test_timer"
 
-    Registry().add_timer(timer_name, timer)
+    registry.add_timer(timer_name, timer)
 
     with pytest.raises(AttributeError) as exec_info:
         new_timer = Timer()
 
-        Registry().add_timer(timer_name, new_timer)
+        registry.add_timer(timer_name, new_timer)
 
     assert exec_info.value.args[0] == f"A timer with the name '{timer_name}' already exists"
 
@@ -140,9 +133,9 @@ def test_get_timer() -> None:
     timer = Timer()
     timer_name = "test_timer"
 
-    Registry().add_timer(timer_name, timer)
+    registry.add_timer(timer_name, timer)
 
-    new_timer = Registry().get_timer(timer_name)
+    new_timer = registry.get_timer(timer_name)
 
     assert new_timer == timer
 
@@ -151,14 +144,14 @@ def test_remove_timer() -> None:
     timer = Timer()
     timer_name = "test_timer"
 
-    Registry().add_timer(timer_name, timer)
+    registry.add_timer(timer_name, timer)
 
-    assert timer_name in Registry().timers
+    assert timer_name in registry.TIMERS
 
-    Registry().remove_timer(timer_name)
+    registry.remove_timer(timer_name)
 
-    assert len(Registry().timers) == 0
-    assert timer_name not in Registry().timers
+    assert len(registry.TIMERS) == 0
+    assert timer_name not in registry.TIMERS
 
 
 def test_clear_registry() -> None:
@@ -171,20 +164,20 @@ def test_clear_registry() -> None:
     timer = Timer()
     timer_name = "test_timer"
 
-    Registry().add_counter(counter_name, counter)
-    Registry().add_gauge(gauge_name, gauge)
-    Registry().add_timer(timer_name, timer)
+    registry.add_counter(counter_name, counter)
+    registry.add_gauge(gauge_name, gauge)
+    registry.add_timer(timer_name, timer)
 
-    assert counter_name in Registry().counters
-    assert gauge_name in Registry().gauges
-    assert timer_name in Registry().timers
+    assert counter_name in registry.COUNTERS
+    assert gauge_name in registry.GAUGES
+    assert timer_name in registry.TIMERS
 
-    Registry().clear()
+    registry.clear()
 
-    assert len(Registry().counters) == 0
-    assert len(Registry().gauges) == 0
-    assert len(Registry().timers) == 0
+    assert len(registry.COUNTERS) == 0
+    assert len(registry.GAUGES) == 0
+    assert len(registry.TIMERS) == 0
 
-    assert counter_name not in Registry().counters
-    assert gauge_name not in Registry().gauges
-    assert timer_name not in Registry().timers
+    assert counter_name not in registry.COUNTERS
+    assert gauge_name not in registry.GAUGES
+    assert timer_name not in registry.TIMERS


### PR DESCRIPTION
Replaced the singleton registry object with a module to make the handling of a global registry of meters more pythonic